### PR TITLE
Azd validate

### DIFF
--- a/.github/workflows/validate-azd-template.yml
+++ b/.github/workflows/validate-azd-template.yml
@@ -1,0 +1,94 @@
+name: Validate Azure Developer CLI Template
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install Azure Developer CLI
+        run: |
+          curl -fsSL https://aka.ms/install-azd.sh | bash
+
+      - name: Install mcp-azd-template
+        run: npm install -g mcp-azd-template      # Run validation and capture the output for potential issue creation
+      - name: Validate AZD Template and Capture Output
+        id: validate
+        run: |
+          # Run validation and capture output to a file
+          mcp-azd-template validate-action "${{ github.workspace }}" > validation_output.txt 2>&1
+          
+          # Check if the validation failed
+          if [ $? -ne 0 ]; then
+            echo "status=failed" >> $GITHUB_OUTPUT
+            cat validation_output.txt
+          else
+            echo "status=success" >> $GITHUB_OUTPUT
+          fi
+        continue-on-error: true
+        # Pass the GitHub token to allow issue creation if enabled
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            # Create issue with detailed validation results when validation fails
+      - name: Create Issue with Validation Results
+        if: ${{ steps.validate.outputs.status == 'failed' && github.event_name == 'push' }}
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            
+            // Read validation output file
+            let validationOutput;
+            try {
+              validationOutput = fs.readFileSync('validation_output.txt', 'utf8');
+            } catch (err) {
+              validationOutput = 'Failed to read validation output: ' + err.message;
+            }
+            
+            // Extract critical issues and warnings for better formatting
+            const criticalIssuesMatch = validationOutput.match(/### ❌ Critical Issues\n([\s\S]*?)(?=\n###|$)/);
+            const warningsMatch = validationOutput.match(/### ⚠️ Warnings and Recommendations\n([\s\S]*?)(?=\n###|$)/);
+            
+            const criticalIssues = criticalIssuesMatch ? criticalIssuesMatch[1].trim() : '';
+            const warnings = warningsMatch ? warningsMatch[1].trim() : '';
+            
+            // Build issue body with proper escaping for YAML
+            let issueBody = `# Template Validation Failed\n\n`;
+            issueBody += `Template validation found issues in commit ${context.sha.substring(0, 7)}.\n\n`;
+            issueBody += `## Validation Results\n\n`;
+            
+            if (criticalIssues) {
+              issueBody += `### Critical Issues\n${criticalIssues}\n\n`;
+            }
+            
+            if (warnings) {
+              issueBody += `### Warnings and Recommendations\n${warnings}\n\n`;
+            }
+            
+            issueBody += `<details>\n<summary>Full Validation Output</summary>\n\n\`\`\`\n${validationOutput}\n\`\`\`\n\n</details>\n\n`;
+            issueBody += `Please address these issues before merging. For more information, see the [workflow run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}).`;
+            
+            // Create issue with formatted validation results
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: 'AZD Template Validation Failed',
+              body: issueBody
+            });
+            });

--- a/.github/workflows/validate-azd-template.yml
+++ b/.github/workflows/validate-azd-template.yml
@@ -29,11 +29,24 @@ jobs:
       - name: Install mcp-azd-template
         run: npm install -g mcp-azd-template
 
+      - name: Handle README.md Case Sensitivity
+        run: |
+          # Debug: List files in the workspace to verify what's available
+          echo "Files in repository root:"
+          ls -la "${{ github.workspace }}"
+          
+          # Check if readme.md exists (case-insensitive check)
+          if [ -f "${{ github.workspace }}/readme.md" ] && [ ! -f "${{ github.workspace }}/README.md" ]; then
+            echo "Found lowercase readme.md, creating symlink to README.md for case-sensitive validation"
+            ln -s "${{ github.workspace }}/readme.md" "${{ github.workspace }}/README.md"
+          fi
+
       - name: Validate AZD Template and Capture Output
         id: validate
         run: |
           # Run validation and save output to a file
           set +e  # Don't exit on error
+          echo "Running validation on path: ${{ github.workspace }}"
           mcp-azd-template validate-action "${{ github.workspace }}" > validation_output.txt 2>&1
           EXIT_CODE=$?
           
@@ -55,7 +68,7 @@ jobs:
 
       # Create issue with detailed validation results when validation fails
       - name: Create Issue with Validation Results
-        if: ${{ steps.validate.outputs.status == 'failed' && github.event_name == 'push' }}
+        if: ${{ steps.validate.outputs.status == 'failed' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -76,22 +89,45 @@ jobs:
             
             const criticalIssues = criticalIssuesMatch ? criticalIssuesMatch[1].trim() : '';
             const warnings = warningsMatch ? warningsMatch[1].trim() : '';
-            
-            // Build issue body with proper escaping for YAML
+              // Build issue body with improved Markdown formatting
             let issueBody = `# Template Validation Failed\n\n`;
-            issueBody += `Template validation found issues in commit ${context.sha.substring(0, 7)}.\n\n`;
+            issueBody += `📝 Template validation found issues in commit \`${context.sha.substring(0, 7)}\`.\n\n`;
             issueBody += `## Validation Results\n\n`;
             
             if (criticalIssues) {
-              issueBody += `### Critical Issues\n${criticalIssues}\n\n`;
+              // Format critical issues with proper bullet points and code formatting
+              const formattedCriticalIssues = criticalIssues
+                .split('\n')
+                .map(line => {
+                  if (line.trim().startsWith('-')) {
+                    // Format each bullet point with better spacing and emphasis
+                    return line.replace(/^- (.+)$/, '- **$1**');
+                  }
+                  return line;
+                })
+                .join('\n');
+              
+              issueBody += `### ❌ Critical Issues\n${formattedCriticalIssues}\n\n`;
             }
             
             if (warnings) {
-              issueBody += `### Warnings and Recommendations\n${warnings}\n\n`;
+              // Format warnings with proper bullet points and code formatting
+              const formattedWarnings = warnings
+                .split('\n')
+                .map(line => {
+                  if (line.trim().startsWith('-')) {
+                    // Format each bullet point with code highlighting where appropriate
+                    return line.replace(/^- (.+?)(\s+in\s+|\s+for\s+)(.+)$/, '- $1$2`$3`');
+                  }
+                  return line;
+                })
+                .join('\n');
+              
+              issueBody += `### ⚠️ Warnings and Recommendations\n${formattedWarnings}\n\n`;
             }
             
             issueBody += `<details>\n<summary>Full Validation Output</summary>\n\n\`\`\`\n${validationOutput}\n\`\`\`\n\n</details>\n\n`;
-            issueBody += `Please address these issues before merging. For more information, see the [workflow run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}).`;
+            issueBody += `---\n\n📌 Please address these issues before merging. For more information, see the [workflow run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}).`;
             
             // Create issue with formatted validation results
             await github.rest.issues.create({

--- a/.github/workflows/validate-azd-template.yml
+++ b/.github/workflows/validate-azd-template.yml
@@ -1,3 +1,4 @@
+# filepath: c:\github\mcp\mcp-azd-template\src\github-workflow-templates\validate-azd-template.yml
 name: Validate Azure Developer CLI Template
 
 on:
@@ -6,6 +7,7 @@ on:
   pull_request:
     branches: [ main ]
   workflow_dispatch:
+    # Additional inputs for manual runs can be defined here if needed
 
 jobs:
   validate:
@@ -19,32 +21,39 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '18'
-          cache: 'npm'
 
       - name: Install Azure Developer CLI
         run: |
           curl -fsSL https://aka.ms/install-azd.sh | bash
 
       - name: Install mcp-azd-template
-        run: npm install -g mcp-azd-template      # Run validation and capture the output for potential issue creation
+        run: npm install -g mcp-azd-template
+
       - name: Validate AZD Template and Capture Output
         id: validate
         run: |
-          # Run validation and capture output to a file
+          # Run validation and save output to a file
+          set +e  # Don't exit on error
           mcp-azd-template validate-action "${{ github.workspace }}" > validation_output.txt 2>&1
+          EXIT_CODE=$?
           
-          # Check if the validation failed
-          if [ $? -ne 0 ]; then
+          # Always display the output for better debugging (useful for workflow_dispatch runs)
+          echo "Validation output:"
+          cat validation_output.txt
+          
+          # Set the status based on exit code
+          if [ $EXIT_CODE -ne 0 ]; then
+            echo "Validation failed with exit code: $EXIT_CODE"
             echo "status=failed" >> $GITHUB_OUTPUT
-            cat validation_output.txt
           else
+            echo "Validation succeeded!"
             echo "status=success" >> $GITHUB_OUTPUT
           fi
         continue-on-error: true
-        # Pass the GitHub token to allow issue creation if enabled
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            # Create issue with detailed validation results when validation fails
+
+      # Create issue with detailed validation results when validation fails
       - name: Create Issue with Validation Results
         if: ${{ steps.validate.outputs.status == 'failed' && github.event_name == 'push' }}
         uses: actions/github-script@v6
@@ -90,5 +99,4 @@ jobs:
               repo: context.repo.repo,
               title: 'AZD Template Validation Failed',
               body: issueBody
-            });
             });


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to validate Azure Developer CLI templates. The workflow includes steps for setting up the environment, running validation, and creating a detailed GitHub issue if validation fails.

### New GitHub Actions Workflow for Template Validation:

* **Workflow Setup**: Introduced a new workflow file, `.github/workflows/validate-azd-template.yml`, to validate Azure Developer CLI templates on `push`, `pull_request`, and `workflow_dispatch` events.
* **Validation Steps**:
  - Installs the necessary dependencies, including Node.js and the Azure Developer CLI.
  - Handles case sensitivity for `README.md` by creating a symlink if only a lowercase version exists.
  - Runs the `mcp-azd-template` validation command, captures the output, and determines success or failure based on the exit code.
* **Error Handling**:
  - On validation failure, creates a detailed GitHub issue with critical issues, warnings, and the full validation output included in a well-formatted Markdown structure.